### PR TITLE
Update @actions/cache to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     ]
   },
   "dependencies": {
-    "@actions/cache": "^3.2.4",
+    "@actions/cache": "^4.0.3",
     "@actions/core": "^1.10.1",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^6.0.0",


### PR DESCRIPTION
To mitigate this. 
https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

Seeing errors like 

```
Restoring cache for omni
  Warning: Failed to restore: getCacheEntry failed: connect ETIMEDOUT 52.152.245.137:443
  omni cache not found for any of omni-v0-linux-x86_64-5795111242029e2b37044c6938989754e924d1f9248175cad02f3ab172495e7d-, omni-v0-linux-x86_64-
```